### PR TITLE
Add DragonField docs, selectors; change CAN bus

### DIFF
--- a/src/main/cpp/chassis/generated/TunerConstants9998.h
+++ b/src/main/cpp/chassis/generated/TunerConstants9998.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "ctre/phoenix6/swerve/SwerveDrivetrain.hpp"
 #include "ctre/phoenix6/CANcoder.hpp"
 #include "ctre/phoenix6/TalonFX.hpp"
+#include "ctre/phoenix6/swerve/SwerveDrivetrain.hpp"
 
 using namespace ctre::phoenix6;
 
@@ -71,7 +71,7 @@ class TunerConstants9998
     // Configs for the Pigeon 2; leave this nullopt to skip applying Pigeon 2 configs
     static constexpr std::optional<configs::Pigeon2Configuration> pigeonConfigs = std::nullopt;
 
-    static constexpr std::string_view kCANBusName = "Canivore";
+    static constexpr std::string_view kCANBusName = "swerve";
 
 public:
     // CAN bus that the devices are located on;

--- a/src/main/cpp/utils/DragonField.cpp
+++ b/src/main/cpp/utils/DragonField.cpp
@@ -13,6 +13,11 @@
 // OR OTHER DEALINGS IN THE SOFTWARE.
 //====================================================================================================================================================
 
+/// @file DragonField.cpp
+/// @brief Implementation of the DragonField class for managing field visualization in SmartDashboard.
+/// @details This class provides a singleton interface for displaying robot position, field objects,
+///          and trajectories on the FRC SmartDashboard Field2d widget.
+
 #include <string>
 
 // FRC Includes
@@ -25,6 +30,8 @@ using std::string;
 
 DragonField *DragonField::m_instance = nullptr;
 
+/// @brief Get the singleton instance of DragonField.
+/// @return Pointer to the singleton DragonField instance.
 DragonField *DragonField::GetInstance()
 {
     if (DragonField::m_instance == nullptr)
@@ -34,17 +41,26 @@ DragonField *DragonField::GetInstance()
     return DragonField::m_instance;
 }
 
+/// @brief Constructor for DragonField.
+/// @details Initializes the Field2d object and registers it with SmartDashboard.
 DragonField::DragonField() : m_field(),
-                             m_objects()
+                             m_objects(),
+                             m_objectNameEnabled()
 {
     frc::SmartDashboard::PutData(&m_field);
 }
 
+/// @brief Update the robot's position on the field display.
+/// @param robotPose The current pose of the robot (position and rotation).
 void DragonField::UpdateRobotPosition(frc::Pose2d robotPose)
 {
     m_field.SetRobotPose(robotPose);
 }
 
+/// @brief Add a field object with an initial pose and enable/disable selector.
+/// @param name The name identifier for the object.
+/// @param pose The initial pose of the object.
+/// @param defaultSelectorValue Whether the object should be enabled by default on the field.
 void DragonField::AddObject(std::string name, frc::Pose2d pose, bool defaultSelectorValue)
 {
     if (!defaultSelectorValue)
@@ -54,12 +70,17 @@ void DragonField::AddObject(std::string name, frc::Pose2d pose, bool defaultSele
     AddSelector(name, defaultSelectorValue);
 }
 
+/// @brief Add a trajectory to be displayed on the field.
+/// @param name The name identifier for the trajectory.
+/// @param trajectory The trajectory to display.
 void DragonField::AddTrajectory(std::string name, frc::Trajectory trajectory)
 {
     m_objects.emplace_back(m_field.GetObject(name));
     m_field.GetObject(name)->SetTrajectory(trajectory);
 }
 
+/// @brief Reset all field objects by clearing their poses.
+/// @details This removes all displayed poses from field objects, effectively clearing the field display.
 void DragonField::ResetField()
 {
     for (auto object : m_objects)
@@ -68,6 +89,9 @@ void DragonField::ResetField()
     }
 }
 
+/// @brief Update the pose of a specific field object if it is enabled.
+/// @param name The name identifier of the object to update.
+/// @param object The new pose for the object.
 void DragonField::UpdateObject(std::string name, frc::Pose2d object)
 {
     auto objectPair = std::find_if(m_objectNameEnabled.begin(), m_objectNameEnabled.end(),
@@ -81,6 +105,9 @@ void DragonField::UpdateObject(std::string name, frc::Pose2d object)
     }
 }
 
+/// @brief Update the enabled/disabled state of all field objects based on SmartDashboard values.
+/// @details Reads boolean values from SmartDashboard for each registered object to determine
+///          whether they should be visible on the field display.
 void DragonField::UpdateEnabledStates()
 {
     for (auto &objectPair : m_objectNameEnabled)
@@ -90,6 +117,9 @@ void DragonField::UpdateEnabledStates()
     }
 }
 
+/// @brief Add a boolean selector to SmartDashboard for enabling/disabling a field object.
+/// @param name The name identifier for the object.
+/// @param defaultValue The default enabled state for the selector.
 void DragonField::AddSelector(std::string name, bool defaultValue)
 {
     frc::SmartDashboard::PutBoolean(name + " Enabled On Field", defaultValue);

--- a/src/main/cpp/utils/DragonField.h
+++ b/src/main/cpp/utils/DragonField.h
@@ -20,30 +20,64 @@
 #include <frc/smartdashboard/FieldObject2d.h>
 #include <frc/trajectory/Trajectory.h>
 
+/// @class DragonField
+/// @brief Singleton class for managing field visualization in SmartDashboard.
+/// @details This class provides a centralized interface for displaying robot position, field objects,
+///          and trajectories on the FRC SmartDashboard Field2d widget. It manages the lifecycle of
+///          field objects and provides methods to update their positions and visibility.
 class DragonField
 {
 public:
+    /// @brief Constructor for DragonField.
+    /// @details Initializes the Field2d object and registers it with SmartDashboard.
     DragonField();
+
+    /// @brief Destructor for DragonField.
     ~DragonField() = default;
 
+    /// @brief Update the robot's position on the field display.
+    /// @param robotPose The current pose of the robot (position and rotation).
     void UpdateRobotPosition(frc::Pose2d robotPose);
 
+    /// @brief Add a field object with an initial pose and enable/disable selector.
+    /// @param name The name identifier for the object.
+    /// @param pose The initial pose of the object.
+    /// @param defaultSelectorValue Whether the object should be enabled by default on the field.
     void AddObject(std::string name, frc::Pose2d pose, bool defaultSelectorValue = false);
+
+    /// @brief Add a trajectory to be displayed on the field.
+    /// @param name The name identifier for the trajectory.
+    /// @param trajectory The trajectory to display.
     void AddTrajectory(std::string name, frc::Trajectory trajectory);
+
+    /// @brief Update the pose of a specific field object if it is enabled.
+    /// @param name The name identifier of the object to update.
+    /// @param pose The new pose for the object.
     void UpdateObject(std::string name, frc::Pose2d pose);
+
+    /// @brief Update the enabled/disabled state of all field objects based on SmartDashboard values.
+    /// @details Reads boolean values from SmartDashboard for each registered object to determine
+    ///          whether they should be visible on the field display.
     void UpdateEnabledStates();
+
     // void UpdateObjectVisionPose(std::string name, std::optional<VisionPose> visionPose);
 
-    /// @brief get the singeleton of FMSData
+    /// @brief Get the singleton instance of DragonField.
+    /// @return Pointer to the singleton DragonField instance.
     static DragonField *GetInstance();
 
+    /// @brief Reset all field objects by clearing their poses.
+    /// @details This removes all displayed poses from field objects, effectively clearing the field display.
     void ResetField();
 
 private:
-    frc::Field2d m_field;
-    std::vector<frc::FieldObject2d *> m_objects;
-    std::vector<std::pair<std::string, bool>> m_objectNameEnabled;
-    static DragonField *m_instance;
+    frc::Field2d m_field;                                          ///< The Field2d object used for visualization
+    std::vector<frc::FieldObject2d *> m_objects;                   ///< List of field objects for trajectories
+    std::vector<std::pair<std::string, bool>> m_objectNameEnabled; ///< Map of object names to their enabled state
+    static DragonField *m_instance;                                ///< Singleton instance pointer
 
+    /// @brief Add a boolean selector to SmartDashboard for enabling/disabling a field object.
+    /// @param name The name identifier for the object.
+    /// @param defaultValue The default enabled state for the selector.
     void AddSelector(std::string name, bool defaultValue);
 };


### PR DESCRIPTION
Add comprehensive Doxygen-style documentation and small API improvements for DragonField: initialize and register Field2d with SmartDashboard, add selectors for toggling objects, add UpdateRobotPosition/AddObject/AddTrajectory/UpdateObject/UpdateEnabledStates/ResetField methods, and initialize m_objectNameEnabled. Also reorder includes and change TunerConstants9998::kCANBusName from "Canivore" to "swerve". These changes improve field visualization clarity and runtime control of which objects/trajectories are shown.