### PR TITLE
Use meter units for Limelight mounting offsets

### DIFF
--- a/src/main/cpp/vision/DragonLimelight.cpp
+++ b/src/main/cpp/vision/DragonLimelight.cpp
@@ -57,9 +57,9 @@ namespace
 /// @param identifier enum identifying which physical limelight this represents
 /// @param cameraType limelight camera type (unused in current implementation)
 /// @param cameraUsage whether this camera is used for odometry, vision, etc. (unused here)
-/// @param mountingXOffset forward offset in inches from robot center
-/// @param mountingYOffset left offset in inches from robot center
-/// @param mountingZOffset up offset in inches from robot center
+/// @param mountingXOffset forward offset in meters from robot center
+/// @param mountingYOffset left offset in meters from robot center
+/// @param mountingZOffset up offset in meters from robot center
 /// @param pitch camera pitch in degrees
 /// @param yaw camera yaw in degrees
 /// @param roll camera roll in degrees

--- a/src/main/cpp/vision/DragonLimelight.h
+++ b/src/main/cpp/vision/DragonLimelight.h
@@ -59,9 +59,9 @@ public:
     /// @param identifier Identifier enum for multiple limelights on the robot.
     /// @param cameraType Type hint for camera hardware/configuration.
     /// @param cameraUsage How the camera will be used (odometry, driver camera, etc.).
-    /// @param mountingXOffset Forward offset (inches) from robot center.
-    /// @param mountingYOffset Left offset (inches) from robot center.
-    /// @param mountingZOffset Up offset (inches) from robot center.
+    /// @param mountingXOffset Forward offset (meters) from robot center.
+    /// @param mountingYOffset Left offset (meters) from robot center.
+    /// @param mountingZOffset Up offset (meters) from robot center.
     /// @param pitch Camera pitch in degrees.
     /// @param yaw Camera yaw in degrees.
     /// @param roll Camera roll in degrees.


### PR DESCRIPTION
Change mounting offset types from units::length::inch_t to units::length::meter_t in DragonLimelight.h and DragonLimelight.cpp. Update calls to SetCameraPose_RobotSpace to pass raw values using .value() instead of .to<double>() for both length and angle types. This standardizes the camera pose API to SI meters and simplifies extraction of numeric values; no other behavior changes introduced.