### PR TITLE
Rename cameras and tweak mounting offsets

### DIFF
--- a/src/main/cpp/vision/DragonLimelight.cpp
+++ b/src/main/cpp/vision/DragonLimelight.cpp
@@ -266,7 +266,8 @@ std::optional<VisionPose> DragonLimelight::GetMegaTag2Pose()
     {
         return std::nullopt;
     }
-
+    auto mode = frc::DriverStation::IsDisabled() ? static_cast<int>(LIMELIGHT_IMU_MODE::USE_EXTERNAL_IMU_AND_FUSE_WITH_INTERNAL_IMU) : static_cast<int>(LIMELIGHT_IMU_MODE::USE_INTERNAL_WITH_MT1_ASSISTED_CONVERGENCE);
+    LimelightHelpers::SetIMUMode(m_networkTableName, mode);
     if (!m_robotPoseSet)
     {
         auto megatag1pose = GetMegaTag1Pose();
@@ -276,8 +277,6 @@ std::optional<VisionPose> DragonLimelight::GetMegaTag2Pose()
         }
     }
     // Get the pose estimate
-    auto mode = frc::DriverStation::IsDisabled() ? static_cast<int>(LIMELIGHT_IMU_MODE::USE_EXTERNAL_IMU_AND_FUSE_WITH_INTERNAL_IMU) : static_cast<int>(LIMELIGHT_IMU_MODE::USE_INTERNAL_WITH_MT1_ASSISTED_CONVERGENCE);
-    LimelightHelpers::SetIMUMode(m_networkTableName, mode);
     auto poseEstimate = LimelightHelpers::getBotPoseEstimate_wpiBlue_MegaTag2(m_networkTableName);
 
     double xyStds = .7;

--- a/src/main/cpp/vision/definitions/CameraConfig_302.cpp
+++ b/src/main/cpp/vision/definitions/CameraConfig_302.cpp
@@ -43,7 +43,7 @@ void CameraConfig_302::BuildCameraConfig()
                                                       DRAGON_LIMELIGHT_LED_MODE::LED_OFF            // DRAGON_LIMELIGHT_LED_MODE ledMode,
 
     ); // additional parameter
-    // vision->AddLimelight(std::move(backLeft), DRAGON_LIMELIGHT_CAMERA_USAGE::APRIL_TAGS);
+    vision->AddLimelight(std::move(backLeft), DRAGON_LIMELIGHT_CAMERA_USAGE::APRIL_TAGS);
 
     auto backRight = std::make_unique<DragonLimelight>(std::string("limelight-right"), // networkTableName
                                                        DRAGON_LIMELIGHT_CAMERA_IDENTIFIER::BACK_CAMERA,
@@ -60,7 +60,6 @@ void CameraConfig_302::BuildCameraConfig()
 
     ); // additional parameter
     vision->AddLimelight(std::move(backRight), DRAGON_LIMELIGHT_CAMERA_USAGE::APRIL_TAGS);
-    vision->AddLimelight(std::move(backLeft), DRAGON_LIMELIGHT_CAMERA_USAGE::APRIL_TAGS);
 
     auto climber = std::make_unique<DragonLimelight>(std::string("limelight-climber"), // networkTableName
                                                      DRAGON_LIMELIGHT_CAMERA_IDENTIFIER::BACK_CAMERA,

--- a/src/main/cpp/vision/definitions/CameraConfig_302.h
+++ b/src/main/cpp/vision/definitions/CameraConfig_302.h
@@ -27,14 +27,14 @@ public:
 
 private:
     static constexpr units::length::inch_t m_ll1MountingXOffset{-10.585};
-    static constexpr units::length::inch_t m_ll1MountingYOffset{10.257};
+    static constexpr units::length::inch_t m_ll1MountingYOffset{-10.257};
     static constexpr units::length::inch_t m_ll1MountingZOffset{9.231};
     static constexpr units::angle::degree_t m_ll1Pitch{5};
     static constexpr units::angle::degree_t m_ll1Yaw{-150};
     static constexpr units::angle::degree_t m_ll1Roll{0};
 
     static constexpr units::length::inch_t m_ll2MountingXOffset{-10.585};
-    static constexpr units::length::inch_t m_ll2MountingYOffset{-10.257};
+    static constexpr units::length::inch_t m_ll2MountingYOffset{10.257};
     static constexpr units::length::inch_t m_ll2MountingZOffset{9.231};
     static constexpr units::angle::degree_t m_ll2Pitch{5};
     static constexpr units::angle::degree_t m_ll2Yaw{150};


### PR DESCRIPTION
Rename limelight network table names from "limelight-backleft"/"limelight-backright" to "limelight-left"/"limelight-right" and adjust AddLimelight ordering so the left camera is registered after the right. Also correct camera mounting parameters: change ll1 yaw from 210 to -150 degrees and update ll3 mounting Z offset from 16.582in to 19.589in. These changes fix camera identification and correct orientation/position for vision calibration.