### PR TITLE
updated pi name

### DIFF
--- a/src/main/cpp/utils/logging/signals/DragonDataLoggerMgr.cpp
+++ b/src/main/cpp/utils/logging/signals/DragonDataLoggerMgr.cpp
@@ -40,7 +40,7 @@ DragonDataLoggerMgr::DragonDataLoggerMgr() : m_items()
 {
 
     //m_logger = std::make_unique<CTRESignalLogger>();
-    m_logger = std::make_unique<UDPSignalLogger>("127.0.0.1", 5900);
+    m_logger = std::make_unique<UDPSignalLogger>("dragondataloggerz.local", 5900);
 
     m_logger->Start();
     m_timer.Start();


### PR DESCRIPTION
This pull request makes a small update to the UDP signal logger configuration. The logger now connects to the hostname `dragondataloggerz.local` instead of the IP address `127.0.0.1`.

- Changed the UDP signal logger initialization in `DragonDataLoggerMgr.cpp` to use the hostname `dragondataloggerz.local` rather than the loopback IP address for logging.