### PR TITLE
Potential Launcher Loop Overrun Fix

### DIFF
--- a/src/main/cpp/mechanisms/Launcher/Launcher.cpp
+++ b/src/main/cpp/mechanisms/Launcher/Launcher.cpp
@@ -644,11 +644,25 @@ void Launcher::SetCurrentState(int state, bool run)
 	StateMgr::SetCurrentState(state, run);
 }
 
+void Launcher::RefreshCachedMotorData()
+{
+	m_cachedLauncherVelocity = m_launcher->GetVelocity().GetValue();
+	m_cachedHoodPosition = m_hood->GetPosition().GetValue();
+	m_cachedTurretPosition = m_turret->GetPosition().GetValue();
+}
+
 void Launcher::RunCommonTasks()
 {
+	// Refresh all motor data once at the start of the loop to avoid multiple CAN bus queries
+	RefreshCachedMotorData();
+
+	if (frc::DriverStation::IsDisabled())
+	{
+		InitilaizeLauncher();
+	}
+
 	// This function is called once per loop before the current state Run()
 	Cyclic();
-	InitilaizeLauncher();
 	SetLauncherProtect();
 
 	// Update Launcher Targets/Field
@@ -730,8 +744,8 @@ bool Launcher::IsLauncherAtTarget()
 		return true;
 	}
 	// Launcher Speed error, Hood Angle error, Turret angle error are within a threshold, and if we are in launch zone. Also check chassis speed.
-	units::angle::degree_t hoodError = m_hood->GetPosition().GetValue() - m_targetHoodAngle;
-	units::angular_velocity::revolutions_per_minute_t launcherSpeedError = m_launcher->GetVelocity().GetValue() - m_targetLauncherAngularVelocity;
+	units::angle::degree_t hoodError = m_cachedHoodPosition - m_targetHoodAngle;
+	units::angular_velocity::revolutions_per_minute_t launcherSpeedError = m_cachedLauncherVelocity - m_targetLauncherAngularVelocity;
 	bool inLaunchzone = IsInLaunchZone();
 	auto chassisSpeeds = m_chassis != nullptr ? m_chassis->GetState().Speeds : frc::ChassisSpeeds();
 
@@ -755,7 +769,7 @@ bool Launcher::IsInLaunchZone() const
 
 void Launcher::CalculateTargets()
 {
-	m_targetTurretAngle = m_targetCalculator->GetLauncherTarget(m_lookaheadTime, m_launcher->GetPosition().GetValue());
+	m_targetTurretAngle = m_targetCalculator->GetLauncherTarget(m_lookaheadTime, m_cachedTurretPosition);
 	units::length::inch_t distanceToTarget = m_targetCalculator->CalculateDistanceToTarget(m_lookaheadTime);
 
 	if (AllianceZoneManager::GetInstance()->IsInAllianceZone())
@@ -771,10 +785,10 @@ void Launcher::CalculateTargets()
 
 	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Distance To Target", distanceToTarget.value());
 	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Hood Angle Target", m_targetHoodAngle.value());
-	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Launcher Turret Angle", m_turret->GetPosition().GetValueAsDouble());
+	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Launcher Turret Angle", m_cachedTurretPosition.value());
 	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Launcher Speed Target", m_targetLauncherAngularVelocity.value());
-	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Launcher Speed RPM", units::angular_velocity::revolutions_per_minute_t(m_launcher->GetVelocity().GetValue()).value());
-	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Hood Angle", m_hood->GetPosition().GetValueAsDouble());
+	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Launcher Speed RPM", units::angular_velocity::revolutions_per_minute_t(m_cachedLauncherVelocity).value());
+	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Hood Angle", m_cachedHoodPosition.value());
 }
 
 void Launcher::UpdateLauncherTargets()
@@ -794,7 +808,7 @@ void Launcher::UpdateLauncherTargets()
 void Launcher::InitilaizeLauncher()
 {
 	if (((m_turret->GetReverseLimit().GetValue() == ctre::phoenix6::signals::ReverseLimitValue::ClosedToGround ||
-		  m_turret->GetForwardLimit().GetValue() == ctre::phoenix6::signals::ReverseLimitValue::ClosedToGround) &&
+		  m_turret->GetForwardLimit().GetValue() == ctre::phoenix6::signals::ForwardLimitValue::ClosedToGround) &&
 		 (m_hood->GetReverseLimit().GetValue() == ctre::phoenix6::signals::ReverseLimitValue::ClosedToGround)) ||
 		frc::RobotBase::IsSimulation())
 	{
@@ -826,7 +840,7 @@ std::string Launcher::GetCurrentStateName()
 
 bool Launcher::IsTurretAtTarget()
 {
-	units::angle::degree_t turretError = m_turret->GetPosition().GetValue() - m_targetTurretAngle;
+	units::angle::degree_t turretError = m_cachedTurretPosition - m_targetTurretAngle;
 
 	return ((units::math::abs(turretError) < m_turretAngleThreshold));
 }

--- a/src/main/cpp/mechanisms/Launcher/Launcher.h
+++ b/src/main/cpp/mechanisms/Launcher/Launcher.h
@@ -234,7 +234,9 @@ private:
 
 	RebuiltTargetCalculator *m_targetCalculator;
 	subsystems::CommandSwerveDrivetrain *m_chassis;
+
 	void CalculateTargets();
+	void RefreshCachedMotorData();
 
 	bool m_launcherInitialized = false;
 	bool m_tuningLauncher = true;
@@ -250,5 +252,9 @@ private:
 	std::array<units::angular_velocity::revolutions_per_minute_t, 7> m_passingLauncherVelocityArray = {500.0_rpm, 600.0_rpm, 700.0_rpm, 800.0_rpm, 900.0_rpm, 1000.0_rpm, 1100.0_rpm};
 	// All values in turns are actually Degree's
 
-	// void InitializeLogging();
+	// Cached motor status signals for performance optimization
+	// These are refreshed once per loop in RunCommonTasks() to avoid multiple CAN bus queries
+	units::angular_velocity::turns_per_second_t m_cachedLauncherVelocity = 0.0_tps;
+	units::angle::turn_t m_cachedHoodPosition = 0.0_tr;
+	units::angle::turn_t m_cachedTurretPosition = 0.0_tr;
 };


### PR DESCRIPTION
Caching all CAN bus signals and only calling initialize launcher check in disabled