### PR TITLE
Add launcher/hood/chassis error tracking and logging

### DIFF
--- a/src/main/cpp/mechanisms/Launcher/Launcher.cpp
+++ b/src/main/cpp/mechanisms/Launcher/Launcher.cpp
@@ -748,23 +748,21 @@ bool Launcher::IsLauncherAtTarget()
 		return true;
 	}
 	// Launcher Speed error, Hood Angle error, Turret angle error are within a threshold, and if we are in launch zone. Also check chassis speed.
-	units::angle::degree_t hoodError = m_cachedHoodPosition - m_targetHoodAngle;
-	units::angular_velocity::revolutions_per_minute_t launcherSpeedError = m_cachedLauncherVelocity - m_targetLauncherAngularVelocity;
-	bool inLaunchzone = IsInLaunchZone();
-	auto chassisSpeeds = m_chassis != nullptr ? m_chassis->GetState().Speeds : frc::ChassisSpeeds();
-	auto Speed = units::math::sqrt(units::math::abs(chassisSpeeds.vx * chassisSpeeds.vx) + units::math::abs(chassisSpeeds.vy * chassisSpeeds.vy));
-
-	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Hood Error", hoodError.value());
-	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Launcher Speed Error", launcherSpeedError.value());
-	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "In Launch Zone", inLaunchzone);
-	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Chassis Speed", Speed.value());
-	Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Turret At Target", IsTurretAtTarget());
-
-	return ((units::math::abs(hoodError) < m_hoodAngleThreshold) &&
+	m_hoodAngleError = m_cachedHoodPosition - m_targetHoodAngle;
+	m_launcherSpeedError = m_cachedLauncherVelocity - m_targetLauncherAngularVelocity;
+	m_isInLaunchZone = IsInLaunchZone();
+	m_chassisSpeeds = m_chassis != nullptr ? m_chassis->GetState().Speeds : frc::ChassisSpeeds();
+	m_chassisSpeed = units::math::sqrt(units::math::abs(m_chassisSpeeds.vx * m_chassisSpeeds.vx) + units::math::abs(m_chassisSpeeds.vy * m_chassisSpeeds.vy));
+	// Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Hood Error", m_hoodAngleError.value());
+	// Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Launcher Speed Error", m_launcherSpeedError.value());
+	// Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "In Launch Zone", m_isInLaunchZone);
+	// Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Chassis Speed", m_chassisSpeed.value());
+	// Logger::GetLogger()->LogData(LOGGER_LEVEL::PRINT, m_ntName, "Turret At Target", IsTurretAtTarget());
+	return ((units::math::abs(m_hoodAngleError) < m_hoodAngleThreshold) &&
 			IsTurretAtTarget() &&
-			(units::math::abs(launcherSpeedError) < m_launcherVelocityThreshold) &&
-			(inLaunchzone) &&
-			(Speed < m_chassisSpeedThreshold));
+			(units::math::abs(m_launcherSpeedError) < m_launcherVelocityThreshold) &&
+			(m_isInLaunchZone) &&
+			(m_chassisSpeed < m_chassisSpeedThreshold));
 }
 
 bool Launcher::IsInLaunchZone() const
@@ -859,6 +857,13 @@ void Launcher::DataLog(uint64_t timestamp)
 	// Mechanism state
 	LogStringData(timestamp, m_loggingLauncherStatePath, GetCurrentStateName());
 	LogBoolData(timestamp, m_loggingProtectedModePath, m_launcherProtectedMode);
+	LogDoubleData(timestamp, m_loggingLauncherSpeedErrorPath, m_cachedLauncherVelocity.value(), m_loggingRPMUnits);
+
+	LogDoubleData(timestamp, m_loggingHoodAngleErrorPath, m_cachedHoodPosition.value(), m_loggingDegreesUnits);
+	LogDoubleData(timestamp, m_loggingLauncherSpeedErrorPath, m_launcherSpeedError.value(), m_loggingRPMUnits);
+	LogDoubleData(timestamp, m_loggingChassisSpeedPath, m_chassisSpeed.value(), m_loggingRPMUnits);
+	LogBoolData(timestamp, m_loggingInLaunchZonePath, m_isInLaunchZone);
+	LogDoubleData(timestamp, m_loggingTurretAngleActualPath, m_cachedTurretPosition.value(), m_loggingTurnsUnits);
 }
 std::string Launcher::GetCurrentStateName()
 {

--- a/src/main/cpp/mechanisms/Launcher/Launcher.h
+++ b/src/main/cpp/mechanisms/Launcher/Launcher.h
@@ -263,6 +263,13 @@ private:
 
 	units::angle::turn_t m_passingHoodTargetAngle = 30.0_tr;
 	units::angular_velocity::revolutions_per_minute_t m_passingLauncherTargetVelocity = 1000.0_rpm;
+
+	units::angular_velocity::revolutions_per_minute_t m_launcherSpeedError = 0.0_rpm;
+	units::angle::degree_t m_hoodAngleError = 0.0_deg;
+	bool m_isInLaunchZone = false;
+	frc::ChassisSpeeds m_chassisSpeeds;
+	units::velocity::meters_per_second_t m_chassisSpeed = 0.0_mps;
+
 	// logging paths
 	static constexpr std::string_view m_loggingLauncherTargetPath = "/Launcher/TargetLauncherVelocity";
 	static constexpr std::string_view m_loggingHoodTargetPath = "/Launcher/HoodTargetAngle";
@@ -270,6 +277,18 @@ private:
 	static constexpr std::string_view m_loggingLauncherStatePath = "/Launcher/State";
 	static constexpr std::string_view m_loggingProtectedModePath = "/Launcher/IsProtectedMode";
 
+	static constexpr std::string_view m_loggingHoodErrorPath = "/Launcher/HoodError";
+	static constexpr std::string_view m_loggingLauncherSpeedErrorPath = "/Launcher/LauncherSpeedError";
+	static constexpr std::string_view m_loggingInLaunchZonePath = "/Launcher/InLaunchZone";
+	static constexpr std::string_view m_loggingChassisSpeedPath = "/Launcher/ChassisSpeed";
+	static constexpr std::string_view m_loggingTurretAtTargetPath = "/Launcher/TurretAtTarget";
+	static constexpr std::string_view m_loggingHoodAngleErrorPath = "/Launcher/HoodAngleError";
+	static constexpr std::string_view m_loggingTurretAngleErrorPath = "/Launcher/TurretAngleError";
+
+	static constexpr std::string_view m_loggingTurretAngleActualPath = "/Launcher/TurretAngleActual";
+
 	static constexpr std::string_view m_loggingTurnsUnits = "Turns";
 	static constexpr std::string_view m_loggingRPMUnits = "RPM";
+	static constexpr std::string_view m_loggingDegreesUnits = "Degrees";
+	static constexpr std::string_view m_loggingFPSUnits = "FPS";
 };


### PR DESCRIPTION
Replace local error calculations in IsLauncherAtTarget with member variables (m_hoodAngleError, m_launcherSpeedError, m_isInLaunchZone, m_chassisSpeeds, m_chassisSpeed) so their values can be reused and recorded. Comment out ad-hoc debug LogData calls and update IsLauncherAtTarget to evaluate readiness using the stored fields. Add new logging paths and unit labels (hood/launcher error, chassis speed, turret actual angle, degrees/FPS units) and extend DataLog() to emit these values for telemetry.