### PR TITLE
Add more data logging to DragonLimelight

### DIFF
--- a/src/main/cpp/vision/DragonLimelight.cpp
+++ b/src/main/cpp/vision/DragonLimelight.cpp
@@ -520,7 +520,7 @@ void DragonLimelight::SetRobotPoseWithMegaTag1()
 
 void DragonLimelight::DataLog(uint64_t timestamp)
 {
-    LogIntData(timestamp, m_loggingLimelightPath + m_networkTableName + "/pipeline", static_cast<int>(m_pipeline));
-    LogPose3dData(timestamp, m_loggingLimelightPath + m_networkTableName + "/cameraPose", m_cameraPose);
-    LogIntData(timestamp, m_loggingLimelightPath + m_networkTableName + "/identifier", static_cast<int>(LimelightHelpers::getRawFiducials(m_networkTableName).size()));
+    LogIntData(timestamp, std::string(m_loggingLimelightPath + m_networkTableName + m_loggingPipelineKey), static_cast<int>(m_pipeline));
+    LogPose3dData(timestamp, std::string(m_loggingLimelightPath + m_networkTableName + m_loggingCameraPoseKey), m_megatag2Pos.estimatedPose);
+    LogIntData(timestamp, std::string(m_loggingLimelightPath + m_networkTableName + m_loggingTagIDKey), static_cast<int>(LimelightHelpers::getRawFiducials(m_networkTableName).size()));
 }

--- a/src/main/cpp/vision/DragonLimelight.h
+++ b/src/main/cpp/vision/DragonLimelight.h
@@ -19,6 +19,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <optional>
 
 // FRC includes
 #include "fielddata/FieldConstants.h"
@@ -237,4 +238,7 @@ private:
     LIMELIGHT_IMU_MODE m_lastIMUMode = LIMELIGHT_IMU_MODE::USE_EXTERNAL_IMU_ONLY;
 
     const std::string m_loggingLimelightPath = "/Limelight/";
+    const std::string m_loggingCameraPoseKey = "cameraPose/";
+    const std::string m_loggingPipelineKey = "pipeline/";
+    const std::string m_loggingTagIDKey = "number of fiducials/";
 };


### PR DESCRIPTION
Make DragonLimelight inherit from DragonDataLogger and implement DataLog(uint64_t) to record pipeline, cameraPose, and fiducial count to the data logger. Remove the now-unused m_numberOfTags member and add the DataLog declaration in the header. Also include the DragonDataLogger header and fix a stray blank line in the source.