### PR TITLE
Make PI time refresh delay configurable

### DIFF
--- a/src/main/cpp/Robot.cpp
+++ b/src/main/cpp/Robot.cpp
@@ -80,6 +80,7 @@
 #include "auton/CyclePrimitives.h"
 #include <chrono>
 #include <frc2/command/CommandScheduler.h>
+#include <networktables/NetworkTableInstance.h>
 // #include "auton/drivePrimitives/AutonUtils.h"
 #include "chassis/ChassisConfigMgr.h"
 #include "feedback/DriverFeedback.h"
@@ -292,7 +293,7 @@ void Robot::UpdatePISystemTime()
 {
     if (m_loggerTable != nullptr)
     {
-        if (m_piUpdateCounter >= 20)
+        if (m_piUpdateCounter == m_piTimeRefreshDelay - 1)
         {
             auto currentTime = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
             m_loggerTable->PutNumber("pi-system-time", static_cast<double>(currentTime));

--- a/src/main/cpp/Robot.h
+++ b/src/main/cpp/Robot.h
@@ -73,4 +73,5 @@ private:
     std::shared_ptr<nt::NetworkTable> m_loggerTable = nullptr;
     subsystems::CommandSwerveDrivetrain *m_chassis = nullptr;
     int m_piUpdateCounter = 0;
+    int m_piTimeRefreshDelay = 20;
 };


### PR DESCRIPTION
Add nt::NetworkTableInstance include and introduce m_piTimeRefreshDelay (default 20) in Robot.h. Update UpdatePISystemTime to trigger only when m_piUpdateCounter == m_piTimeRefreshDelay - 1 instead of >= 20 so the PI system time is written once per configured interval and avoids repeated writes when the counter exceeds the threshold.